### PR TITLE
Add CI workflow and basic test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: wms-api:test
+      - run: docker compose -f docker-compose.yml up -d db
+      - run: pytest backend/tests
+
+  deploy:
+    needs: build-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/deploy-cloudrun@v1
+        with:
+          service: wms-api
+          image: gcr.io/$PROJECT_ID/wms-api:${{ github.sha }}

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from backend.app.main import app
+
+client = TestClient(app)
+
+def test_health():
+    response = client.get('/health')
+    assert response.status_code == 200
+    assert response.json() == {'status': 'ok'}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for build, test and deploy
- add sample `pytest` for `/health` endpoint

## Testing
- `pytest backend/tests -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68695dc2719c832196937101174b4a55