### PR TITLE
Seed DB with sample data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,7 @@ up:
 	docker-compose up -d --build
 
 down:
-	docker-compose down
+        docker-compose down
+
+load:
+        docker-compose run --rm backend python -m app.scripts.load_data

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ This repository contains a minimal warehouse management system prototype using t
    ```bash
    make up
    ```
-5. Visit `http://localhost:3000` for the UI and `http://localhost:8000/docs` for the API docs.
+5. Load some sample inventory and order data:
+   ```bash
+   make load
+   ```
+6. Visit `http://localhost:3000` for the UI and `http://localhost:8000/docs` for the API docs.
 
 To run backend tests locally:
 ```bash

--- a/backend/app/api/items.py
+++ b/backend/app/api/items.py
@@ -1,15 +1,12 @@
-from fastapi import APIRouter
-from pydantic import BaseModel
-
-class Item(BaseModel):
-    id: int
-    name: str
+from fastapi import APIRouter, Depends
+from sqlmodel import Session, select
+from ..core.database import get_session
+from ..models.item import Item
 
 router = APIRouter()
 
-items_db = [Item(id=1, name="Widget"), Item(id=2, name="Gadget")]
 
 @router.get("/", response_model=list[Item])
-def list_items():
-    return items_db
+def list_items(session: Session = Depends(get_session)):
+    return session.exec(select(Item)).all()
 

--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -1,16 +1,12 @@
-from fastapi import APIRouter
-from pydantic import BaseModel
-
-class Order(BaseModel):
-    id: int
-    item_id: int
-    quantity: int
+from fastapi import APIRouter, Depends
+from sqlmodel import Session, select
+from ..core.database import get_session
+from ..models.order import Order
 
 router = APIRouter()
 
-orders_db = [Order(id=1, item_id=1, quantity=5)]
 
 @router.get("/", response_model=list[Order])
-def list_orders():
-    return orders_db
+def list_orders(session: Session = Depends(get_session)):
+    return session.exec(select(Order)).all()
 

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,3 +1,4 @@
+from typing import Generator
 from sqlmodel import SQLModel, create_engine, Session
 from .config import settings
 
@@ -8,6 +9,8 @@ def init_db():
     SQLModel.metadata.create_all(engine)
 
 
-def get_session():
-    return Session(engine)
+def get_session() -> Generator[Session, None, None]:
+    """Yield a new SQLModel session."""
+    with Session(engine) as session:
+        yield session
 

--- a/backend/app/scripts/load_data.py
+++ b/backend/app/scripts/load_data.py
@@ -1,0 +1,26 @@
+from sqlmodel import Session
+from ..core.database import init_db, engine
+from ..models.item import Item
+from ..models.order import Order
+
+
+def load_data() -> None:
+    """Create sample items and orders in the database."""
+    init_db()
+    with Session(engine) as session:
+        # Skip seeding if items already exist
+        if session.query(Item).first():
+            print("Data already loaded")
+            return
+        widget = Item(name="Widget")
+        gadget = Item(name="Gadget")
+        session.add_all([widget, gadget])
+        session.commit()
+
+        order = Order(item_id=widget.id, quantity=5)
+        session.add(order)
+        session.commit()
+
+
+if __name__ == "__main__":
+    load_data()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "vite": "^4.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- load sample items and orders into the database
- update item and order APIs to query the database
- expose database session as dependency
- document new `make load` command

## Testing
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686972dc4a6c8321acf329558536089f