### PR TITLE
Refine Makefile and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,12 @@ jobs:
           file: ./backend/Dockerfile
           push: false
           tags: wms-api:test
-      - run: docker compose -f docker-compose.yml up -d db
+      - run: make up
       - run: pip install ./backend
+      - run: pip install pytest
       - run: pytest backend/tests
+      - run: make down
+        if: always()
 
   deploy:
     needs: build-test

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
+.PHONY: up down load
+
 up:
-	docker-compose up -d --build
+	docker compose up -d --build
 
 down:
-        docker-compose down
+	docker compose down
 
 load:
-        docker-compose run --rm backend python -m app.scripts.load_data
+	docker compose run --rm backend python -m app.scripts.load_data

--- a/README.md
+++ b/README.md
@@ -32,8 +32,13 @@ This repository contains a minimal warehouse management system prototype using t
    make load
    ```
 6. Visit `http://localhost:3000` for the UI and `http://localhost:8000/docs` for the API docs.
+7. When you're finished, stop all services:
+   ```bash
+   make down
+   ```
 
 To run backend tests locally:
 ```bash
+pip install -e ./backend pytest
 pytest backend/tests
 ```


### PR DESCRIPTION
## Summary
- switch make commands to use `docker compose`
- document installing pytest before running tests
- ensure GitHub Actions installs pytest

## Testing
- `pip install ./backend` *(fails: network access needed)*
- `pytest -q backend/tests/test_health.py` *(fails: fastapi not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6869800e05ac8321b9003906362846fc