### PR TITLE
Fix BaseSettings import

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     database_url: str = "sqlite:///./test.db"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "scikit-learn",
     "prophet",
     "ortools",
+    "pydantic-settings",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- fix BaseSettings import for FastAPI
- add pydantic-settings to backend dependencies

## Testing
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686982d88678832190acf358283f7c2c