### PR TITLE
Fix circular import and module detection

### DIFF
--- a/backend/app/models/item.py
+++ b/backend/app/models/item.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from sqlmodel import SQLModel, Field, Relationship
-from .order import Order
 
 class Item(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)

--- a/backend/app/models/order.py
+++ b/backend/app/models/order.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 from sqlmodel import SQLModel, Field, Relationship
-from .item import Item
 
 class Order(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     item_id: int | None = Field(default=None, foreign_key="item.id")
     quantity: int
-    item: Item | None = Relationship(back_populates="orders")
+    item: "Item" | None = Relationship(back_populates="orders")
 
 


### PR DESCRIPTION
## Summary
- make backend a package
- resolve circular imports between models

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686984eb6a6c8321aad066830f3b54f6