### PR TITLE
Fix missing select import

### DIFF
--- a/backend/app/scripts/load_data.py
+++ b/backend/app/scripts/load_data.py
@@ -1,5 +1,5 @@
 
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from ..core.database import init_db, engine
 from ..models.item import Item


### PR DESCRIPTION
## Summary
- import select in load_data script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -e ./backend` *(fails: Could not find a version that satisfies the requirement setuptools)*

------
https://chatgpt.com/codex/tasks/task_e_686986dad71c8321a32d90b4082b9053