### PR TITLE
Fix SQLModel relationship hints

### DIFF
--- a/backend/app/models/item.py
+++ b/backend/app/models/item.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from typing import List, Optional
+
+from sqlalchemy.orm import Mapped
 from sqlmodel import SQLModel, Field, Relationship
 
+
 class Item(SQLModel, table=True):
-    id: int | None = Field(default=None, primary_key=True)
+    id: Optional[int] = Field(default=None, primary_key=True)
     name: str
 
-    orders: list["Order"] = Relationship(back_populates="item")
-
+    orders: Mapped[List["Order"]] = Relationship(back_populates="item")

--- a/backend/app/models/order.py
+++ b/backend/app/models/order.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from typing import Optional
+
+from sqlalchemy.orm import Mapped
 from sqlmodel import SQLModel, Field, Relationship
 
+
 class Order(SQLModel, table=True):
-    id: int | None = Field(default=None, primary_key=True)
-    item_id: int | None = Field(default=None, foreign_key="item.id")
+    id: Optional[int] = Field(default=None, primary_key=True)
+    item_id: Optional[int] = Field(default=None, foreign_key="item.id")
     quantity: int
-    item: "Item" | None = Relationship(back_populates="orders")
-
-
+    item: Mapped[Optional["Item"]] = Relationship(back_populates="orders")


### PR DESCRIPTION
## Summary
- fix Item and Order relationship annotations for compatibility with SQLAlchemy 2

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686988702e90832195be0e11b95dceed