### PR TITLE
Fix SQLModel annotations

### DIFF
--- a/backend/app/models/item.py
+++ b/backend/app/models/item.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Optional
 
 from sqlalchemy.orm import Mapped, relationship
 from sqlmodel import SQLModel, Field
@@ -10,4 +10,4 @@ class Item(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str
 
-    orders: Mapped[List["Order"]] = relationship(back_populates="item")
+    orders: Mapped[list["Order"]] = relationship(back_populates="item")

--- a/backend/app/models/order.py
+++ b/backend/app/models/order.py
@@ -10,4 +10,4 @@ class Order(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     item_id: Optional[int] = Field(default=None, foreign_key="item.id")
     quantity: int
-    item: Mapped[Optional["Item"]] = relationship(back_populates="orders")
+    item: Mapped["Item | None"] = relationship(back_populates="orders")


### PR DESCRIPTION
## Summary
- update Item and Order models to use Python 3.12 compatible type annotations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68698afbed6c8321a18c355e23b90f8b