### PR TITLE
Add dashboard metrics feature

### DIFF
--- a/backend/app/api/dashboard.py
+++ b/backend/app/api/dashboard.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/", summary="Get dashboard metrics")
+def get_dashboard():
+    """Return sample dashboard metrics."""
+    return {
+        "totalSKUs": 20,
+        "totalItems": 150,
+        "inventoryValue": 3400.0,
+        "pendingOrders": 5,
+        "lowStockItems": 2,
+        "criticalAlerts": 1,
+        "inventoryByCategory": [
+            {"category": "Widgets", "count": 50},
+            {"category": "Gadgets", "count": 100},
+        ],
+        "orderStatusData": [
+            {"status": "new", "count": 3},
+            {"status": "processing", "count": 1},
+            {"status": "packed", "count": 1},
+        ],
+        "recentActivities": [
+            {
+                "id": "1",
+                "action": "added",
+                "item": "Widget A",
+                "quantity": 10,
+                "timestamp": "2024-01-01T12:00:00Z",
+            }
+        ],
+        "lowStockList": [
+            {
+                "id": "1",
+                "name": "Widget B",
+                "currentStock": 2,
+                "minStock": 5,
+                "reorderQuantity": 10,
+            }
+        ],
+    }

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter
-from . import items, orders
+from . import items, orders, dashboard
 
 api_router = APIRouter()
 
 api_router.include_router(items.router, prefix="/items", tags=["items"])
 api_router.include_router(orders.router, prefix="/orders", tags=["orders"])
+api_router.include_router(dashboard.router, prefix="/dashboard", tags=["dashboard"])
 

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -1,0 +1,13 @@
+from fastapi.testclient import TestClient
+from backend.app.main import app
+
+client = TestClient(app)
+
+
+def test_dashboard():
+    response = client.get('/dashboard')
+    assert response.status_code == 200
+    data = response.json()
+    assert 'totalSKUs' in data
+    assert 'totalItems' in data
+    assert 'pendingOrders' in data

--- a/frontend/src/components/KeyMetricCard.tsx
+++ b/frontend/src/components/KeyMetricCard.tsx
@@ -1,0 +1,15 @@
+interface Props {
+  title: string;
+  value: string | number;
+  onView?: () => void;
+}
+
+export default function KeyMetricCard({ title, value, onView }: Props) {
+  return (
+    <div style={{ border: '1px solid #ccc', padding: '0.5rem', borderRadius: 4, width: 160 }}>
+      <h4 style={{ margin: 0 }}>{title}</h4>
+      <div style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>{value}</div>
+      {onView && <button onClick={onView}>View Details</button>}
+    </div>
+  );
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,3 +1,44 @@
+import { useEffect, useState } from 'react';
+import KeyMetricCard from '../components/KeyMetricCard';
+import { DashboardData, fetchDashboard } from '../services/dashboard';
+
 export default function Dashboard() {
-  return <div>Dashboard</div>
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      setData(await fetchDashboard());
+      setError(null);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error}</div>;
+  if (!data) return null;
+
+  return (
+    <div>
+      <h2>Dashboard</h2>
+      <button onClick={load}>Refresh</button>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem', marginTop: '1rem' }}>
+        <KeyMetricCard title="Total SKUs" value={data.totalSKUs} />
+        <KeyMetricCard title="Total Items" value={data.totalItems} />
+        <KeyMetricCard title="Inventory Value" value={`$${data.inventoryValue}`} />
+        <KeyMetricCard title="Pending Orders" value={data.pendingOrders} />
+        <KeyMetricCard title="Low Stock Items" value={data.lowStockItems} />
+        <KeyMetricCard title="Critical Alerts" value={data.criticalAlerts} />
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/services/dashboard.ts
+++ b/frontend/src/services/dashboard.ts
@@ -1,0 +1,44 @@
+import { fetchJson } from '../api';
+
+export interface InventoryByCategory {
+  category: string;
+  count: number;
+}
+
+export interface OrderStatusData {
+  status: string;
+  count: number;
+}
+
+export interface RecentActivity {
+  id: string;
+  action: string;
+  item: string;
+  quantity: number;
+  timestamp: string;
+}
+
+export interface LowStockItem {
+  id: string;
+  name: string;
+  currentStock: number;
+  minStock: number;
+  reorderQuantity: number;
+}
+
+export interface DashboardData {
+  totalSKUs: number;
+  totalItems: number;
+  inventoryValue: number;
+  pendingOrders: number;
+  lowStockItems: number;
+  criticalAlerts: number;
+  inventoryByCategory: InventoryByCategory[];
+  orderStatusData: OrderStatusData[];
+  recentActivities: RecentActivity[];
+  lowStockList: LowStockItem[];
+}
+
+export async function fetchDashboard(): Promise<DashboardData> {
+  return fetchJson<DashboardData>('/dashboard');
+}


### PR DESCRIPTION
## Summary
- serve dashboard metrics from a new backend endpoint
- include new dashboard API route
- provide a dashboard test case
- show key metrics in frontend dashboard
- add KeyMetricCard component and dashboard service

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68698b6a1d448321aae3f52e9c14175f