### PR TITLE
Fix relationship annotations for SQLModel

### DIFF
--- a/backend/app/models/item.py
+++ b/backend/app/models/item.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, TYPE_CHECKING, List
 
-from sqlalchemy.orm import Mapped, relationship
-from sqlmodel import SQLModel, Field
+from sqlmodel import SQLModel, Field, Relationship
+
+if TYPE_CHECKING:
+    from .order import Order
 
 
 class Item(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str
 
-    orders: Mapped[list["Order"]] = relationship(back_populates="item")
+    orders: List["Order"] = Relationship(back_populates="item")

--- a/backend/app/models/order.py
+++ b/backend/app/models/order.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
-from sqlalchemy.orm import Mapped, relationship
-from sqlmodel import SQLModel, Field
+from sqlmodel import SQLModel, Field, Relationship
+
+if TYPE_CHECKING:
+    from .item import Item
 
 
 class Order(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     item_id: Optional[int] = Field(default=None, foreign_key="item.id")
     quantity: int
-    item: Mapped["Item | None"] = relationship(back_populates="orders")
+    item: Optional["Item"] = Relationship(back_populates="orders")


### PR DESCRIPTION
## Summary
- update `Item` and `Order` models to use `Relationship`
- rely on `TYPE_CHECKING` to avoid circular imports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68698c5f1224832199868fdeae1310d6