### PR TITLE
Fix SQLModel relationship forward references

### DIFF
--- a/backend/app/models/item.py
+++ b/backend/app/models/item.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Optional, TYPE_CHECKING, List
 
 from sqlmodel import SQLModel, Field, Relationship

--- a/backend/app/models/order.py
+++ b/backend/app/models/order.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Optional, TYPE_CHECKING
 
 from sqlmodel import SQLModel, Field, Relationship


### PR DESCRIPTION
## Summary
- drop `__future__` annotations import which broke relationship forward references

## Testing
- `pytest -q backend/tests` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6869926cd3b48321ab2d37db0b62f6f0