### PR TITLE
Fix relationship typing

### DIFF
--- a/backend/app/models/item.py
+++ b/backend/app/models/item.py
@@ -1,4 +1,4 @@
-from typing import Optional, TYPE_CHECKING, List
+from typing import Optional, TYPE_CHECKING
 
 from sqlmodel import SQLModel, Field, Relationship
 
@@ -10,4 +10,4 @@ class Item(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str
 
-    orders: List["Order"] = Relationship(back_populates="item")
+    orders: list["Order"] = Relationship(back_populates="item")


### PR DESCRIPTION
## Summary
- avoid passing `List` generic to `Relationship`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6869933c282083218f5247d9a2d67be2