### PR TITLE
Enhance dashboard with charts and lists

### DIFF
--- a/frontend/src/components/KeyMetricCard.tsx
+++ b/frontend/src/components/KeyMetricCard.tsx
@@ -1,15 +1,40 @@
 interface Props {
-  title: string;
-  value: string | number;
-  onView?: () => void;
+  title: string
+  value: string | number
+  icon?: string
+  color?: string
+  onView?: () => void
 }
 
-export default function KeyMetricCard({ title, value, onView }: Props) {
+export default function KeyMetricCard({ title, value, icon, color, onView }: Props) {
   return (
-    <div style={{ border: '1px solid #ccc', padding: '0.5rem', borderRadius: 4, width: 160 }}>
-      <h4 style={{ margin: 0 }}>{title}</h4>
-      <div style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>{value}</div>
+    <div
+      style={{
+        border: '1px solid #ccc',
+        padding: '0.5rem',
+        borderRadius: 4,
+        width: 160,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.25rem',
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <h4 style={{ margin: 0 }}>{title}</h4>
+        {icon && (
+          <span
+            style={{
+              width: 24,
+              height: 24,
+              borderRadius: '50%',
+              background: color || '#eee',
+              display: 'inline-block',
+            }}
+          />
+        )}
+      </div>
+      <div style={{ fontSize: '1.5rem' }}>{value}</div>
       {onView && <button onClick={onView}>View Details</button>}
     </div>
-  );
+  )
 }

--- a/frontend/src/components/dashboard/InventoryChart.tsx
+++ b/frontend/src/components/dashboard/InventoryChart.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { InventoryByCategory } from '../../services/dashboard'
+
+interface Props {
+  data: InventoryByCategory[]
+}
+
+export default function InventoryChart({ data }: Props) {
+  return (
+    <div>
+      <h3>Inventory by Category</h3>
+      {data.map((d) => (
+        <div key={d.category} style={{ display: 'flex', alignItems: 'center', marginBottom: 4 }}>
+          <div style={{ width: 120 }}>{d.category}</div>
+          <div style={{ background: '#4caf50', height: 10, width: d.count * 5 }} />
+          <div style={{ marginLeft: 8 }}>{d.count}</div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/dashboard/LowStockList.tsx
+++ b/frontend/src/components/dashboard/LowStockList.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { LowStockItem } from '../../services/dashboard'
+
+interface Props {
+  items: LowStockItem[]
+}
+
+export default function LowStockList({ items }: Props) {
+  return (
+    <div>
+      <h3>Low Stock Items</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Current</th>
+            <th>Min</th>
+            <th>Reorder</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((i) => (
+            <tr key={i.id}>
+              <td>{i.name}</td>
+              <td>{i.currentStock}</td>
+              <td>{i.minStock}</td>
+              <td>{i.reorderQuantity}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/components/dashboard/OrderStatusChart.tsx
+++ b/frontend/src/components/dashboard/OrderStatusChart.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { OrderStatusData } from '../../services/dashboard'
+
+interface Props {
+  data: OrderStatusData[]
+}
+
+export default function OrderStatusChart({ data }: Props) {
+  return (
+    <div>
+      <h3>Orders / Shipments Status</h3>
+      {data.map((d) => (
+        <div key={d.status} style={{ display: 'flex', alignItems: 'center', marginBottom: 4 }}>
+          <div style={{ width: 120 }}>{d.status}</div>
+          <div style={{ background: '#2196f3', height: 10, width: d.count * 5 }} />
+          <div style={{ marginLeft: 8 }}>{d.count}</div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/dashboard/RecentActivity.tsx
+++ b/frontend/src/components/dashboard/RecentActivity.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { RecentActivity as Activity } from '../../services/dashboard'
+
+interface Props {
+  activities: Activity[]
+}
+
+export default function RecentActivity({ activities }: Props) {
+  return (
+    <div>
+      <h3>Recent Inventory Changes</h3>
+      <ul>
+        {activities.map((a) => (
+          <li key={a.id}>
+            {a.timestamp}: {a.action} {a.quantity} {a.item}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,44 +1,56 @@
-import { useEffect, useState } from 'react';
-import KeyMetricCard from '../components/KeyMetricCard';
-import { DashboardData, fetchDashboard } from '../services/dashboard';
+import KeyMetricCard from '../components/KeyMetricCard'
+import InventoryChart from '../components/dashboard/InventoryChart'
+import OrderStatusChart from '../components/dashboard/OrderStatusChart'
+import RecentActivity from '../components/dashboard/RecentActivity'
+import LowStockList from '../components/dashboard/LowStockList'
+import { useDashboardData } from '../services/dashboard'
 
 export default function Dashboard() {
-  const [data, setData] = useState<DashboardData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { data, loading, error, refetch } = useDashboardData()
 
-  const load = async () => {
-    setLoading(true);
-    try {
-      setData(await fetchDashboard());
-      setError(null);
-    } catch (err: any) {
-      setError(err.message);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    load();
-  }, []);
-
-  if (loading) return <div>Loading...</div>;
-  if (error) return <div>Error: {error}</div>;
-  if (!data) return null;
+  if (loading) return <div>Loading...</div>
+  if (error) return <div>Error: {error}</div>
+  if (!data) return null
 
   return (
     <div>
-      <h2>Dashboard</h2>
-      <button onClick={load}>Refresh</button>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <h2>Dashboard</h2>
+        <button onClick={refetch}>Refresh</button>
+      </div>
+
+      <div style={{ display: 'flex', gap: '0.5rem', margin: '1rem 0' }}>
+        <button>Create New Order</button>
+        <button>Receive Goods</button>
+        <button>Start Picking</button>
+      </div>
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
+        <KeyMetricCard title="Total SKUs" value={data.totalSKUs} color="#4caf50" icon="category" />
+        <KeyMetricCard title="Total Items" value={data.totalItems} color="#2196f3" icon="inventory" />
+        <KeyMetricCard title="Inventory Value" value={`$${data.inventoryValue}`} color="#ff9800" icon="money" />
+        <KeyMetricCard title="Pending Orders" value={data.pendingOrders} color="#f44336" icon="pending" />
+        <KeyMetricCard title="Low Stock Items" value={data.lowStockItems} color="#ff5722" icon="warning" />
+        <KeyMetricCard title="Critical Alerts" value={data.criticalAlerts} color="#d32f2f" icon="error" />
+      </div>
+
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem', marginTop: '1rem' }}>
-        <KeyMetricCard title="Total SKUs" value={data.totalSKUs} />
-        <KeyMetricCard title="Total Items" value={data.totalItems} />
-        <KeyMetricCard title="Inventory Value" value={`$${data.inventoryValue}`} />
-        <KeyMetricCard title="Pending Orders" value={data.pendingOrders} />
-        <KeyMetricCard title="Low Stock Items" value={data.lowStockItems} />
-        <KeyMetricCard title="Critical Alerts" value={data.criticalAlerts} />
+        <div style={{ flex: 1, minWidth: 280 }}>
+          <InventoryChart data={data.inventoryByCategory} />
+        </div>
+        <div style={{ flex: 1, minWidth: 280 }}>
+          <OrderStatusChart data={data.orderStatusData} />
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem', marginTop: '1rem' }}>
+        <div style={{ flex: 1, minWidth: 280 }}>
+          <RecentActivity activities={data.recentActivities} />
+        </div>
+        <div style={{ flex: 1, minWidth: 280 }}>
+          <LowStockList items={data.lowStockList} />
+        </div>
       </div>
     </div>
-  );
+  )
 }

--- a/frontend/src/services/dashboard.ts
+++ b/frontend/src/services/dashboard.ts
@@ -1,4 +1,5 @@
-import { fetchJson } from '../api';
+import { fetchJson } from '../api'
+import { useEffect, useState } from 'react'
 
 export interface InventoryByCategory {
   category: string;
@@ -41,4 +42,30 @@ export interface DashboardData {
 
 export async function fetchDashboard(): Promise<DashboardData> {
   return fetchJson<DashboardData>('/dashboard');
+}
+
+export function useDashboardData() {
+  const [data, setData] = useState<DashboardData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = async () => {
+    setLoading(true)
+    try {
+      setData(await fetchDashboard())
+      setError(null)
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    load()
+    const id = setInterval(load, 5 * 60 * 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  return { data, loading, error, refetch: load }
 }


### PR DESCRIPTION
## Summary
- display more metrics on the dashboard
- add simple charts and lists for inventory and orders
- update key metric card component for icons and colors
- provide a hook for refreshing dashboard data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6869935c1cb88321b570a7017ccd018d