### PR TITLE
Fix dashboard API base URL

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,5 +1,7 @@
-export async function fetchJson<T>(url: string): Promise<T> {
-  const res = await fetch(url)
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+
+export async function fetchJson<T>(path: string): Promise<T> {
+  const res = await fetch(`${API_URL}${path}`)
   if (!res.ok) throw new Error(res.statusText)
   return res.json()
 }


### PR DESCRIPTION
## Summary
- make the frontend API helper accept a base URL
- document the API URL in an example env file

## Testing
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686995e082f88321a4005fbecec37302