### PR TITLE
Add inventory and orders pages

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -3,9 +3,9 @@ import { Link, Outlet } from 'react-router-dom'
 export default function Layout() {
   return (
     <div>
-      <nav>
-        <Link to="/">Dashboard</Link> |
-        <Link to="/inventory">Inventory</Link> |
+      <nav style={{ display: 'flex', gap: '1rem', marginBottom: '1rem' }}>
+        <Link to="/">Dashboard</Link>
+        <Link to="/inventory">Inventory</Link>
         <Link to="/orders">Orders</Link>
       </nav>
       <Outlet />

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -1,3 +1,22 @@
+import { useItems } from '../services/items'
+
 export default function Inventory() {
-  return <div>Inventory</div>
+  const { items, loading, error, refetch } = useItems()
+
+  if (loading) return <div>Loading...</div>
+  if (error) return <div>Error: {error}</div>
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <h2>Inventory</h2>
+        <button onClick={refetch}>Refresh</button>
+      </div>
+      <ul>
+        {items.map((item) => (
+          <li key={item.id}>{item.name}</li>
+        ))}
+      </ul>
+    </div>
+  )
 }

--- a/frontend/src/pages/Orders.tsx
+++ b/frontend/src/pages/Orders.tsx
@@ -1,3 +1,35 @@
+import { useOrders } from '../services/orders'
+
 export default function Orders() {
-  return <div>Orders</div>
+  const { orders, loading, error, refetch } = useOrders()
+
+  if (loading) return <div>Loading...</div>
+  if (error) return <div>Error: {error}</div>
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <h2>Orders</h2>
+        <button onClick={refetch}>Refresh</button>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Item ID</th>
+            <th>Quantity</th>
+          </tr>
+        </thead>
+        <tbody>
+          {orders.map((o) => (
+            <tr key={o.id}>
+              <td>{o.id}</td>
+              <td>{o.item_id}</td>
+              <td>{o.quantity}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
 }

--- a/frontend/src/services/items.ts
+++ b/frontend/src/services/items.ts
@@ -1,0 +1,35 @@
+import { fetchJson } from '../api'
+import { useEffect, useState } from 'react'
+
+export interface Item {
+  id: number
+  name: string
+}
+
+export async function fetchItems(): Promise<Item[]> {
+  return fetchJson<Item[]>('/items')
+}
+
+export function useItems() {
+  const [items, setItems] = useState<Item[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = async () => {
+    setLoading(true)
+    try {
+      setItems(await fetchItems())
+      setError(null)
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  return { items, loading, error, refetch: load }
+}

--- a/frontend/src/services/orders.ts
+++ b/frontend/src/services/orders.ts
@@ -1,0 +1,36 @@
+import { fetchJson } from '../api'
+import { useEffect, useState } from 'react'
+
+export interface Order {
+  id: number
+  item_id: number | null
+  quantity: number
+}
+
+export async function fetchOrders(): Promise<Order[]> {
+  return fetchJson<Order[]>('/orders')
+}
+
+export function useOrders() {
+  const [orders, setOrders] = useState<Order[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = async () => {
+    setLoading(true)
+    try {
+      setOrders(await fetchOrders())
+      setError(null)
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  return { orders, loading, error, refetch: load }
+}


### PR DESCRIPTION
## Summary
- add basic layout styling
- display lists in Inventory and Orders pages
- fetch item and order data from API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6869a0cd82288321afa3823316cfaf72