### PR TITLE
Handle /items without redirect

### DIFF
--- a/backend/app/api/items.py
+++ b/backend/app/api/items.py
@@ -7,6 +7,8 @@ router = APIRouter()
 
 
 @router.get("/", response_model=list[Item])
+@router.get("", include_in_schema=False)
 def list_items(session: Session = Depends(get_session)):
+    """Return all items without forcing a trailing slash."""
     return session.exec(select(Item)).all()
 

--- a/backend/tests/test_items.py
+++ b/backend/tests/test_items.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+from backend.app.main import app
+
+client = TestClient(app)
+
+
+def test_items_without_redirect():
+    no_slash = client.get('/items')
+    with_slash = client.get('/items/')
+    assert no_slash.status_code == 200
+    assert with_slash.status_code == 200
+    assert no_slash.json() == with_slash.json()


### PR DESCRIPTION
## Summary
- allow /items without a trailing slash
- add regression test for new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6869a206cc248321964f46cdd4c83dad