### PR TITLE
Fix /orders 307 redirect

### DIFF
--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -7,6 +7,8 @@ router = APIRouter()
 
 
 @router.get("/", response_model=list[Order])
+@router.get("", include_in_schema=False)
 def list_orders(session: Session = Depends(get_session)):
+    """Return all orders without forcing a trailing slash."""
     return session.exec(select(Order)).all()
 

--- a/backend/tests/test_orders.py
+++ b/backend/tests/test_orders.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+from backend.app.main import app
+
+client = TestClient(app)
+
+
+def test_orders_without_redirect():
+    no_slash = client.get('/orders')
+    with_slash = client.get('/orders/')
+    assert no_slash.status_code == 200
+    assert with_slash.status_code == 200
+    assert no_slash.json() == with_slash.json()


### PR DESCRIPTION
## Summary
- support `/orders` without a trailing slash on the API
- test that `/orders` works like `/orders/`

## Testing
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*

------
https://chatgpt.com/codex/tasks/task_e_6869a45f5d888321b721fbe4988b250c