### PR TITLE
Add Cloud Run deployment auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,15 @@ jobs:
   deploy:
     needs: build-test
     runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      CLOUDSDK_CORE_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
     steps:
+      - uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
       - uses: google-github-actions/deploy-cloudrun@v1
         with:
           service: wms-api
           image: gcr.io/$PROJECT_ID/wms-api:${{ github.sha }}
+          region: us-central1

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains a minimal warehouse management system prototype using t
 - **scikit-learn**, **Facebook Prophet**, **OR-Tools** for forecasting and optimisation
 - **React 18 + TypeScript** (Vite) for the front end
 - **JWT authentication** via FastAPI Users
-- Docker, docker-compose and GitHub Actions CI (workflow not included)
+- Docker, docker-compose and GitHub Actions CI for deployment to Cloud Run
 - Custom Nginx config to support React Router
 
 ## Running Locally
@@ -43,3 +43,17 @@ To run backend tests locally:
 pip install -e ./backend pytest
 pytest backend/tests
 ```
+
+## GitHub Actions Deployment
+
+The repository includes a workflow that builds and tests the backend, then
+deploys the container image to Cloud Run. Configure the following GitHub
+secrets so the deployment step can authenticate and target the correct
+project:
+
+- `GCP_PROJECT_ID` – your Google Cloud project ID.
+- `GCP_SERVICE_ACCOUNT_KEY` – a service account key JSON with permissions to
+  deploy to Cloud Run.
+
+The workflow uses these secrets to authenticate and sets `PROJECT_ID` when
+running `gcloud`. Ensure both secrets are present for successful deployments.


### PR DESCRIPTION
## Summary
- deploy workflow now authenticates with GCP
- specify project ID via secrets and document the CI setup

## Testing
- `pytest backend/tests` *(fails: 2 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6869a49cc44c8321a4afed9a674c8aed