### PR TITLE
Add basic Hardhat contract and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,25 @@ project:
 
 The workflow uses these secrets to authenticate and sets `PROJECT_ID` when
 running `gcloud`. Ensure both secrets are present for successful deployments.
+
+## Smart Contracts
+
+This repository includes a simple Hardhat project used to compile and test Solidity contracts. The main contract, `NewsPublisher.sol`, allows the owner to publish articles and lets users vote on them.
+
+### Usage
+
+1. Install Node.js (version 18+ recommended).
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Compile the contracts:
+   ```bash
+   npm run compile
+   ```
+4. Run the tests:
+   ```bash
+   npm test
+   ```
+
+> **Note**: Installing dependencies requires internet access to download packages such as Hardhat and OpenZeppelin.

--- a/contracts/NewsPublisher.sol
+++ b/contracts/NewsPublisher.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * @title NewsPublisher
+ * @dev Simple contract to publish articles and vote on them.
+ */
+contract NewsPublisher is Ownable {
+    struct Article {
+        uint256 id;
+        address author;
+        string title;
+        string content;
+        uint256 votes;
+    }
+
+    Article[] private articles;
+    mapping(uint256 => mapping(address => bool)) private hasVoted;
+
+    event ArticlePublished(uint256 indexed id, address indexed author, string title);
+    event ArticleVoted(uint256 indexed id, address indexed voter);
+
+    /**
+     * @dev Publish a new article. Only the contract owner may call this.
+     */
+    function publishArticle(string calldata title, string calldata content) external onlyOwner {
+        uint256 id = articles.length;
+        articles.push(Article({
+            id: id,
+            author: msg.sender,
+            title: title,
+            content: content,
+            votes: 0
+        }));
+        emit ArticlePublished(id, msg.sender, title);
+    }
+
+    /**
+     * @dev Vote for a given article. Each address may vote once per article.
+     */
+    function vote(uint256 articleId) external {
+        require(articleId < articles.length, "Invalid article");
+        require(!hasVoted[articleId][msg.sender], "Already voted");
+
+        hasVoted[articleId][msg.sender] = true;
+        articles[articleId].votes += 1;
+
+        emit ArticleVoted(articleId, msg.sender);
+    }
+
+    /**
+     * @dev Return all published articles.
+     */
+    function getAllArticles() external view returns (Article[] memory) {
+        return articles;
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,0 +1,6 @@
+require("@nomicfoundation/hardhat-toolbox");
+
+/** @type import('hardhat/config').HardhatUserConfig */
+module.exports = {
+  solidity: "0.8.20",
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "wms-prototype",
+  "version": "1.0.0",
+  "description": "This repository contains a minimal warehouse management system prototype using the following stack:",
+  "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "hardhat test",
+    "compile": "hardhat compile"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "hardhat": "^2.20.0",
+    "@nomicfoundation/hardhat-toolbox": "^3.0.0",
+    "@openzeppelin/contracts": "^5.0.0"
+  }
+}

--- a/test/NewsPublisher.js
+++ b/test/NewsPublisher.js
@@ -1,0 +1,34 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("NewsPublisher", function () {
+  let owner, other, newsPublisher;
+
+  beforeEach(async function () {
+    [owner, other] = await ethers.getSigners();
+    const NewsPublisher = await ethers.getContractFactory("NewsPublisher");
+    newsPublisher = await NewsPublisher.deploy();
+    await newsPublisher.waitForDeployment();
+  });
+
+  it("owner can publish articles", async function () {
+    await expect(newsPublisher.publishArticle("title", "content"))
+      .to.emit(newsPublisher, "ArticlePublished")
+      .withArgs(0, owner.address, "title");
+    const articles = await newsPublisher.getAllArticles();
+    expect(articles.length).to.equal(1);
+  });
+
+  it("non-owner cannot publish articles", async function () {
+    await expect(newsPublisher.connect(other).publishArticle("x", "y"))
+      .to.be.revertedWith("Ownable: caller is not the owner");
+  });
+
+  it("allows voting only once", async function () {
+    await newsPublisher.publishArticle("title", "content");
+    await newsPublisher.connect(other).vote(0);
+    await expect(newsPublisher.connect(other).vote(0)).to.be.revertedWith("Already voted");
+    const articles = await newsPublisher.getAllArticles();
+    expect(articles[0].votes).to.equal(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add Hardhat configuration and NewsPublisher contract
- provide tests for publishing and voting
- document smart contract usage
- include package.json with required dependencies

## Testing
- `npx hardhat compile` *(fails: 403 Forbidden)*
- `npm test` *(fails: hardhat: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bd88a367c8321bbfd616e95d5ec07